### PR TITLE
Support C++11 and above

### DIFF
--- a/const.h
+++ b/const.h
@@ -69,7 +69,7 @@ int64_t _TIME_();
 #define DLOG(c,...) //fprintf(stderr,c,##__VA_ARGS__)
 #endif
 #define ERROR(c,...)\
-	{ fprintf (stderr, "(ERROR) "c, ##__VA_ARGS__); exit (1); }
+	{ fprintf (stderr, "(ERROR) " c, ##__VA_ARGS__); exit (1); }
 
 
 // Max. characters per line


### PR DESCRIPTION
Without this patch, compiling with C++11 or above standard will fail:

```
ld -r -b binary -o HELP.o HELP
ld -r -b binary -o patterns.o patterns.bin
g++ -c -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -DSCALCE_VERSION=\"2.8\" -I zlib-1.2.11 -I bzip2-1.0.6 -O3 -DNDEBUG const.cpp -o const.o
In file included from const.cpp:39:0:
const.cpp: In function ‘void* mallox(size_t)’:
const.h:72:21: error: unable to find string literal operator ‘operator""c’ with ‘const char [9]’, ‘long unsigned int’ arguments
  { fprintf (stderr, "(ERROR) "c, ##__VA_ARGS__); exit (1); }
                     ^
const.cpp:96:12: note: in expansion of macro ‘ERROR’
  if (!v) { ERROR("mallox failed whoa whoa whoa!\n");  return 0; }
            ^~~~~
Makefile:33: recipe for target 'const.o' failed
make: *** [const.o] Error 1
```